### PR TITLE
Fixes download link for models

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -89,7 +89,7 @@ impl Model {
 
         download_file(
             &format!(
-                "https://huggingface.co/datasets/ggerganov/whisper.cpp/resolve/main/ggml-{}.bin",
+                "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-{}.bin",
                 self.size
             ),
             path.to_str().unwrap(),


### PR DESCRIPTION
The URL currently in use requests the user to log in. This causes errors in trying to download models since the login page is downloaded in place of the ggml file.

Removing /datasets from the URL resolves this issue and allows downloading datasets as intended.